### PR TITLE
Persist Saved Position and avoid duplicates

### DIFF
--- a/main.js
+++ b/main.js
@@ -80,22 +80,26 @@ function getWords() {
   // create a copy of the savedWords array
   const newWords = savedWords.concat();
 
+  // create an hashtable of the newWords
+  let wordsTable = {};
+  newWords.forEach(e => {
+    if (e && e.word) {
+      wordsTable[e.word] = e;
+    }
+  });
+
   // loop through newWords array and generate data to fill empty positions
   for (let i = 0; i < newWords.length; i++) {
     if (!newWords[i]) {
-      let wordsTable = {};
-      newWords.forEach(e => {
-        if (e && e.word) {
-          wordsTable[e.word] = e;
-        }
-      });
       let dataGenerated = data[generateRand(len)];
-      
       // if data  generated is already in view generate another
       while (wordsTable[dataGenerated.word]) {
+        // uncomment the next comment to see how we captured words that wants to appear twice
+        // console.log("I caught you ", wordsTable[dataGenerated.word]);
         dataGenerated = data[generateRand(len)];
       }
       newWords[i] = dataGenerated;
+      wordsTable[newWords[i].word] = newWords
     }
   }
 

--- a/main.js
+++ b/main.js
@@ -2,30 +2,34 @@ function getElemId(id) {
   return document.getElementById(id);
 }
 
-const wordsDisplay = getElemId('words');
-const generateBtn = getElemId('generate-btn');
-const copyBtn = getElemId('copy');
-let savedWords = [];
+const wordsDisplay = getElemId("words");
+const generateBtn = getElemId("generate-btn");
+const copyBtn = getElemId("copy");
+
+// create placeholders to save words
+let savedWords = [null, null, null];
 function generateRand(end) {
   return Math.floor(Math.random() * end);
 }
 
 function createWord({ word, meaning }) {
-  const sectionElement = document.createElement('section');
-  const wordElement = document.createElement('h2');
-  const meaningElement = document.createElement('p');
-  const saveButton = document.createElement('button');
-  saveButton.addEventListener('click', e => saveWord(e))
+  const sectionElement = document.createElement("section");
+  const wordElement = document.createElement("h2");
+  const meaningElement = document.createElement("p");
+  const saveButton = document.createElement("button");
+  saveButton.addEventListener("click", e => saveWord(e));
   wordElement.textContent = word;
   meaningElement.textContent = meaning;
-  saveButton.textContent = 'save';
-  savedWords.forEach(e => {
-    if (word === e.word) saveButton.textContent = 'saved';
-  })
-
+  saveButton.textContent = "save";
   sectionElement.appendChild(wordElement);
   sectionElement.appendChild(meaningElement);
-  sectionElement.appendChild(saveButton)
+  sectionElement.appendChild(saveButton);
+  savedWords.forEach(e => {
+    if (e && word === e.word) {
+      saveButton.textContent = "saved";
+      saveButton.previousSibling.previousSibling.classList.add("saved");
+    }
+  });
 
   return sectionElement;
 }
@@ -35,61 +39,86 @@ function saveWord(e) {
   let wordObject = {
     word: e.target.previousSibling.previousSibling.textContent,
     meaning: e.target.previousSibling.textContent
-  }
+  };
 
   // check if the word has been saved
-  let exists  = false;
+  let exists = false;
   savedWords.forEach(e => {
-    if (e.word === wordObject.word) {
+    if (e && e.word === wordObject.word) {
       exists = true;
-    };
-  })
+    }
+  });
 
   // if the word has been saved, unsave it
   if (exists) {
-    savedWords = savedWords.filter(e => e.word !== wordObject.word)
-    e.target.textContent = 'save';
+    savedWords = savedWords.map(e => {
+      if (e && e.word !== wordObject.word) {
+        return e;
+      }
+      return null;
+    });
+    e.target.textContent = "save";
+    e.target.previousSibling.previousSibling.classList.remove("saved");
   }
 
-  // if the word has not been saved and 
-  // there is available space, save it 
-  if (!exists && savedWords.length < 3) {
-    e.target.textContent = 'saved';
-    savedWords.push(wordObject);
-  } 
+  // if the word has not been saved, save it
+  if (!exists) {
+    e.target.textContent = "saved";
+    e.target.previousSibling.previousSibling.classList.add("saved");
+    let sectionLists = e.target.parentElement.parentElement.children;
+    sectionLists = Array.from(sectionLists);
+    sectionLists.forEach((element, index) => {
+      if (element.children[0].textContent == wordObject.word)
+        savedWords[index] = wordObject;
+    });
+  }
 }
 
 function getWords() {
   const len = data.length;
-  const newWords = []
-  const wordsToGenerate = 3 - savedWords.length;
 
-  for (let i = 0; i < wordsToGenerate; i++) {
-    newWords.push(data[generateRand(len)])
+  // create a copy of the savedWords array
+  const newWords = savedWords.concat();
+
+  // loop through newWords array and generate data to fill empty positions
+  for (let i = 0; i < newWords.length; i++) {
+    if (!newWords[i]) {
+      let wordsTable = {};
+      newWords.forEach(e => {
+        if (e && e.word) {
+          wordsTable[e.word] = e;
+        }
+      });
+      let dataGenerated = data[generateRand(len)];
+      
+      // if data  generated is already in view generate another
+      while (wordsTable[dataGenerated.word]) {
+        dataGenerated = data[generateRand(len)];
+      }
+      newWords[i] = dataGenerated;
+    }
   }
 
-  const wordsToDisplay = savedWords.concat(newWords)
-  
-  wordsDisplay.innerHTML = '';
-  wordsToDisplay.forEach(word => {
+  wordsDisplay.innerHTML = "";
+  newWords.forEach(word => {
     const newWord = createWord(word);
     wordsDisplay.appendChild(newWord);
   });
 }
 
 function ToggleCopied() {
-  const copied = getElemId('copied');
-  const mainSection = document.getElementsByClassName('main')[0];
+  const copied = getElemId("copied");
+  const mainSection = document.getElementsByClassName("main")[0];
 
   if (!copied) {
-    const copiedEl = document.createElement('p');
-    copiedEl.id = 'copied';
-    copiedEl.textContent = 'Copied Words 📝';
-    copiedEl.style.fontSize = '2rem';
-    copiedEl.style.margin = 'center';
-    copiedEl.style.color = 'gray';
-    copiedEl.style.borderRadius = '3px';
-    copiedEl.style.fontWeight = '700';
+    const copiedEl = document.createElement("p");
+    copiedEl.id = "copied";
+    copiedEl.textContent = "Copied Words 📝";
+    copiedEl.style.fontSize = "2rem";
+    copiedEl.style.margin = "center";
+    copiedEl.style.color = "gray";
+    copiedEl.style.borderRadius = "3px";
+    copiedEl.style.fontWeight = "700";
     mainSection.appendChild(copiedEl);
 
     setTimeout(() => {
@@ -99,22 +128,22 @@ function ToggleCopied() {
 }
 
 function copyWords() {
-  const el = document.createElement('textarea');
-  const wordsEls = document.querySelectorAll('#words > section > h2');
-  let wordsToCopy = '';
+  const el = document.createElement("textarea");
+  const wordsEls = document.querySelectorAll("#words > section > h2");
+  let wordsToCopy = "";
   wordsEls.forEach((el, index) => {
-    if (index != 0) wordsToCopy += ', ';
+    if (index != 0) wordsToCopy += ", ";
     wordsToCopy += el.textContent;
   });
   el.value = wordsToCopy;
-  el.setAttribute('readonly', '');
+  el.setAttribute("readonly", "");
   document.body.appendChild(el);
   el.select();
-  document.execCommand('copy');
+  document.execCommand("copy");
   ToggleCopied(); // Invoke the copied function to display on page
   document.body.removeChild(el);
 }
 
-generateBtn.addEventListener('click', getWords);
-copyBtn.addEventListener('click', copyWords);
+generateBtn.addEventListener("click", getWords);
+copyBtn.addEventListener("click", copyWords);
 getWords();

--- a/styles.css
+++ b/styles.css
@@ -60,6 +60,14 @@ button:hover {
   background-color: cyan
 }
 
+.saved ~ button {
+  background-color: cyan;
+}
+
+.saved:after {
+  content: " 🔒"
+}
+
 .main > .btn {
   width: 350px;
   display: flex;


### PR DESCRIPTION
#### What does this PR do?
- This PR persists the position of the word when saved
- and avoid word duplicates

#### Description of Task to be completed?
- create a placeholder for saved words
- clone save words array and replace empty placeholders with new words
- while the generated word already exists, generate a new one.
- add locks to saved words
- persist the saved button's color

#### How should this be manually tested?
- checkout `feat-persist-saved-position`
- open `index.html` on your browser

#### Relevant Screenshots (if appropriate)
![persist-saved-words](https://user-images.githubusercontent.com/12853775/71236019-1bb36280-22fe-11ea-9267-e84cc9c0e7f4.gif)

